### PR TITLE
Improve links to examples in the FAQ

### DIFF
--- a/pages/doc/faq.md
+++ b/pages/doc/faq.md
@@ -37,7 +37,7 @@ Azul3D provides a set of packages for developing games and other interactive 2D 
 ## Are there any examples?
 
 Yes! You can download and compile them by following the instructions found on the <a href="/doc/install">installation page.
-Alternatively, [view the source on GitHub](https://github.com).
+Alternatively, [view the source on GitHub](https://github.com/azul3d).
 
 ## Why OpenGL 2?
 

--- a/pages/doc/faq.md
+++ b/pages/doc/faq.md
@@ -36,7 +36,7 @@ Azul3D provides a set of packages for developing games and other interactive 2D 
 
 ## Are there any examples?
 
-Yes! You can download and compile them by following the instructions found on the <a href="/doc/install">installation page.
+Yes! You can download and compile them by following the instructions found on the [installation page](/doc/install).
 Alternatively, [view the source on GitHub](https://github.com/azul3d).
 
 ## Why OpenGL 2?


### PR DESCRIPTION
One of the links wasn't terminated, the other one pointed to the front page of github.com, instead of the azul3d organization.