### PR TITLE
Remove trailing slash from repository's home URL.

### DIFF
--- a/main.go
+++ b/main.go
@@ -219,7 +219,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 		<meta name="go-import" content="azul3d.org/engine git https://github.com/azul3d/engine">
-		<meta name="go-source" content="azul3d.org/engine https://github.com/azul3d/engine/ https://github.com/azul3d/engine/tree/master{/dir} https://github.com/azul3d/engine/blob/master{/dir}/{file}#L{line}">
+		<meta name="go-source" content="azul3d.org/engine https://github.com/azul3d/engine https://github.com/azul3d/engine/tree/master{/dir} https://github.com/azul3d/engine/blob/master{/dir}/{file}#L{line}">
 		<meta http-equiv="refresh" content="0; url=https://godoc.org/azul3d.org%s">
 	</head>
 	<body>
@@ -235,7 +235,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 	<meta name="go-import" content="azul3d.org/examples git https://github.com/azul3d/examples">
-	<meta name="go-source" content="azul3d.org/examples https://github.com/azul3d/examples/ https://gotools.org/azul3d.org/examples{/dir} https://gotools.org/azul3d.org/examples{/dir}#{file}-L{line}">
+	<meta name="go-source" content="azul3d.org/examples https://github.com/azul3d/examples https://gotools.org/azul3d.org/examples{/dir} https://gotools.org/azul3d.org/examples{/dir}#{file}-L{line}">
 	<meta http-equiv="refresh" content="0; url=https://godoc.org/azul3d.org%s">
 </head>
 <body>


### PR DESCRIPTION
The second field of go-source meta tag is documented as:

> The home field is the URL of the repository's home page.

You're using the GitHub repository page as the home page URL. However, the canonical URL for a GitHub repository does not have a trailing slash. E.g., if you click on any repo from any link to it on GitHub, it won't have the trailing slash (but explicitly navigating doesn't redirect).

/cc @slimsag